### PR TITLE
Add Slack notifications to GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,3 +37,17 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Notify Slack on build success
+      if: success()
+      uses: slackapi/slack-github-action@v1.25.0
+      with:
+        payload: '{"text":"Build completed successfully!"}'
+        channel: '#alerts'
+        token: ${{ secrets.SLACK_BOT_TOKEN }}
+    - name: Notify Slack on build failure
+      if: failure()
+      uses: slackapi/slack-github-action@v1.25.0
+      with:
+        payload: '{"text":"Build failed!"}'
+        channel: '#alerts'
+        token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,31 @@ license: mit
 ---
 
 Check out the configuration reference at https://huggingface.co/docs/hub/spaces-config-reference
+
+## Slack Notifications Configuration
+
+To configure Slack notifications in your GitHub Actions workflow, you can use the `slackapi/slack-github-action` action. This action allows you to send messages to a specified Slack channel upon the completion of your build.
+
+### Example Configuration
+
+Here is an example of how to add Slack notifications to your GitHub Actions workflow:
+
+```yaml
+- name: Notify Slack on build success
+  if: success()
+  uses: slackapi/slack-github-action@v1.25.0
+  with:
+    payload: '{"text":"Build completed successfully!"}'
+    channel: '#alerts'
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+- name: Notify Slack on build failure
+  if: failure()
+  uses: slackapi/slack-github-action@v1.25.0
+  with:
+    payload: '{"text":"Build failed!"}'
+    channel: '#alerts'
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
+Make sure to add the `SLACK_BOT_TOKEN` secret to your GitHub repository settings.


### PR DESCRIPTION
Add Slack notifications to GitHub Actions workflow.

* **README.md**
  - Add a section to explain the Slack notification configuration.
  - Mention the `slackapi/slack-github-action` usage for notifications.

* **.github/workflows/python-app.yml**
  - Add a step to notify Slack on build success.
  - Add a step to notify Slack on build failure.
  - Use `slackapi/slack-github-action` for Slack notifications.

## Summary by Sourcery

CI:
- Send Slack notifications on build success and failure using the `slackapi/slack-github-action` GitHub Action. The notifications will be sent to the `#alerts` Slack channel using a bot token stored as a secret in the repository settings. The messages will indicate whether the build succeeded or failed.