### PR TITLE
Fix code scanning alert - Call to requests without timeout

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def fetch_article_content(news_link):
     if parsed_url.netloc not in ALLOWED_DOMAINS:
         st.error("The provided URL is not allowed.")
         return None
-    response = requests.get(news_link)
+    response = requests.get(news_link, timeout=10)
     if response.status_code != 200:
         st.error(f"Failed to fetch the article. Status code: {response.status_code}")
         return None


### PR DESCRIPTION
Add a timeout parameter to the `requests.get` call in `app.py`.

* Modify the `requests.get(news_link)` call to include a `timeout` parameter set to 10 seconds.

## Summary by Sourcery

Bug Fixes:
- Prevent potential hangs by setting a timeout for HTTP requests when fetching news articles.